### PR TITLE
Update tyk380_v2.keymap

### DIFF
--- a/app/boards/arm/tyk380/tyk380_v2.keymap
+++ b/app/boards/arm/tyk380/tyk380_v2.keymap
@@ -6,6 +6,7 @@
 
 #include <behaviors.dtsi>
 #include <dt-bindings/zmk/keys.h>
+#include <dt-bindings/zmk/bt.h>
 
 / {
     keymap {
@@ -18,33 +19,38 @@
             // | SHIFT |  Z   |  X   |  C   |  V   |  B   |   N   |  M    |  ,   |  .   |   /   |  RET  |
             // |       | LCTL | LALT | LGUI | LOWR |     SPACE    |  RAIS | LARW | DARW | UARW  |  RARW |
             bindings = <
-                &kp A
-                &kp B
-                &kp C
-                &kp D
-                &kp E
-                &kp F
-                &kp G
-                &kp H
-                &kp I
-                &kp J
-                &kp K
-                &kp L
-                &kp M
-                &kp N
-                &kp O
-                &kp P
-                &kp Q
-                &kp R
-                &kp S
-                &kp T
-                &kp U
-                &kp V
-                &kp W
-                &kp X
-                &kp Y
-                &kp Z
-            >;
+&kp ESC    &kp F1  &kp F2   &kp F3    &kp F4  &kp F5  &kp F6  &kp F7  &kp F8  &kp F9    &kp F10   &kp F11   &kp F12    &kp INS   &kp DEL
+&kp GRAVE  &kp N1  &kp N2   &kp N3    &kp N4  &kp N5  &kp N6  &kp N7  &kp N8  &kp N9    &kp N0    &kp MINUS &kp EQUAL  &kp BSPC
+&kp TAB    &kp Q   &kp W    &kp E     &kp R   &kp T   &kp Y   &kp U   &kp I   &kp  O    &kp P     &kp LBKT  &kp RBKT   &kp RET
+&kp CLCK   &kp A   &kp S    &kp D     &kp F   &kp G   &kp H   &kp J   &kp K   &kp  L    &kp SEMI  &kp SQT   &kp NUBS
+&kp LSHFT  &kp LT  &kp Z    &kp X     &kp C   &kp V   &kp B   &kp N   &kp M   &kp COMMA &kp DOT   &kp FSLH         &kp RSHFT
+&kp LCTRL  &mo 1 &kp LGUI &kp LALT               &kp SPACE                  &kp RALT  &kp RCTRL &kp LEFT  &kp UP &kp DOWN   &kp RIGHT
+        >;
         };
+		
+		func {
+
+            bindings = <
+&bt BT_CLR  &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &trans  &trans  &trans  &trans  &trans  &trans    &trans   &trans   &trans    &trans   &trans
+&trans  &trans  &trans   &trans    &trans  &trans  &trans  &trans  &trans  &trans    &trans    &trans &trans  &trans
+&trans    &trans   &trans    &trans     &trans   &trans   &trans   &trans   &trans   &trans    &trans     &trans  &trans   &trans
+&trans   &trans   &trans    &trans     &trans   &trans   &trans   &trans   &trans   &trans    &trans  &trans   &trans
+&trans  &trans  &trans    &trans     &trans   &trans   &trans   &trans   &trans   &trans &trans   &trans         &trans
+&trans  &trans &trans &trans               &trans                  &trans  &trans &trans  &trans &trans   &trans
+        >;
+        };
+
+		lower {
+
+            bindings = <
+&trans  &trans  &trans   &trans    &trans  &trans  &trans  &trans  &trans  &trans    &trans   &trans   &trans    &trans   &trans
+&trans  &trans  &trans   &trans    &trans  &trans  &trans  &trans  &trans  &trans    &trans    &trans &trans  &trans
+&trans  &trans   &trans    &trans     &trans   &trans   &trans   &trans   &trans   &trans    &trans     &trans  &trans   &trans
+&trans  &trans   &trans    &trans     &trans   &trans   &trans   &trans   &trans   &trans    &trans  &trans   &trans
+&trans  &trans  &trans    &trans     &trans   &trans   &trans   &trans   &trans   &trans &trans   &trans         &trans
+&trans  &trans &trans &trans               &trans                  &trans  &trans &trans  &trans &trans   &trans
+        >;
+        };
+
     };
 };


### PR DESCRIPTION
add basic keymap that works with dts matrix definition

<!-- If you're adding a board/shield please fill out this check-list, otherwise you can delete it -->

## Board/Shield Check-list

- [ ] This board/shield is tested working on real hardware
- [ ] Definitions follow the general style of other shields/boards upstream ([Reference](https://zmk.dev/docs/development/new-shield))
- [ ] `.zmk.yml` metadata file added
- [ ] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [ ] General consistent formatting of DeviceTree files
- [ ] Keymaps do not use deprecated key defines (Check using the [upgrader tool](https://zmk.dev/docs/codes/keymap-upgrader))
- [ ] `&pro_micro` used in favor of `&pro_micro_d/a` if applicable
- [ ] If split, no name added for the right/peripheral half
- [ ] Kconfig.defconfig file correctly wraps _all_ configuration in conditional on the shield symbol
- [ ] `.conf` file has optional extra features commented out
- [ ] Keyboard/PCB is part of a shipped group buy or is generally available in stock to purchase (OSH/personal projects without general availability should create a zmk-config repo instead)
