### PR TITLE
add pin definitions based on matrix

### DIFF
--- a/app/boards/arm/tyk380/tyk380_v2.dts
+++ b/app/boards/arm/tyk380/tyk380_v2.dts
@@ -10,7 +10,7 @@
 
 #include <zephyr/sys/util_macro.h>
 
-#define DECLARE_ROW(X) <&gpio0 X (GPIO_ACTIVE_HIGH | GPIO_OPEN_SOURCE)>
+#define DECLARE_ROW(X) <&gpio0 X (GPIO_ACTIVE_HIGH)>
 #define DECLARE_COL(X) <&gpio0 X (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
 
 / {
@@ -30,50 +30,48 @@
         diode-direction = "row2col";
         row-gpios =
             FOR_EACH(DECLARE_ROW, (,),
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7,
-            8,
             9,
             10,
             11,
             12,
             13,
             14,
+			15,
             16,
             17,
             18,
             19,
             20,
             21,
-            22,
-            28,
-            29,
-            30,
-            31
+            22
             );
         col-gpios =
             FOR_EACH(DECLARE_COL, (,),
-            15
+            0,
+			1,
+			2,
+			3,
+			4,
+			5,
+			6,
+			7,
+			8,
+            28,
+            29
             );
     };
 
     default_transform: keymap_transform_0 {
         compatible = "zmk,matrix-transform";
-        columns = <1>;
-        rows = <26>;
+        columns = <11>;
+        rows = <14>;
         map = <
-            RC(0,0) RC(1,0) RC(2,0) RC(3,0) RC(4,0)
-            RC(5,0) RC(6,0) RC(7,0) RC(8,0) RC(9,0)
-            RC(10,0) RC(11,0) RC(12,0) RC(13,0) RC(14,0)
-            RC(15,0) RC(16,0) RC(17,0) RC(18,0) RC(19,0)
-            RC(20,0) RC(21,0) RC(22,0) RC(23,0) RC(24,0)
-            RC(25,0)
+            RC(4,8)  RC(0,1)  RC(10,7) RC(12,7) RC(5,8) RC(4,7)  RC(6,7) RC(4,9) RC(5,0) RC(5,2)  RC(4,1) RC(3,9) RC(6,0)  RC(3,7) RC(3,2)
+            RC(2,6)  RC(12,8) RC(10,8) RC(7,8)  RC(1,6) RC(13,8) RC(1,8) RC(2,0) RC(3,5) RC(2,4)  RC(2,5) RC(6,5) RC(5,10) RC(4,10)
+			RC(2,8)  RC(8,8)  RC(6,10) RC(2,10) RC(0,4) RC(13,7) RC(0,8) RC(3,4) RC(1,1) RC(4,5)  RC(3,0) RC(8,7) RC(11,8) RC(4,3)
+            RC(8,5)  RC(5,1)  RC(4,2)  RC(3,3)  RC(5,6) RC(0,0)  RC(0,2) RC(2,2) RC(6,2) RC(1,9)  RC(6,4) RC(6,3) RC(2,1)
+            RC(13,9) RC(11,7) RC(9,7)  RC(2,7)  RC(1,5) RC(0,7)  RC(9,8) RC(6,6) RC(5,4) RC(3,10) RC(2,9) RC(1,7) RC(13,10)
+            RC(11,2) RC(7,6) RC(9,4) RC(12,0)             RC(7,7)           RC(12,1) RC(10,3) RC(0,5) RC(1,4) RC(1,0) RC(0,9)
         >;
     };
 };


### PR DESCRIPTION
integrated pin definitions based on discovered matrix

<!-- If you're adding a board/shield please fill out this check-list, otherwise you can delete it -->

## Board/Shield Check-list

- [ ] This board/shield is tested working on real hardware
- [ ] Definitions follow the general style of other shields/boards upstream ([Reference](https://zmk.dev/docs/development/new-shield))
- [ ] `.zmk.yml` metadata file added
- [ ] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [ ] General consistent formatting of DeviceTree files
- [ ] Keymaps do not use deprecated key defines (Check using the [upgrader tool](https://zmk.dev/docs/codes/keymap-upgrader))
- [ ] `&pro_micro` used in favor of `&pro_micro_d/a` if applicable
- [ ] If split, no name added for the right/peripheral half
- [ ] Kconfig.defconfig file correctly wraps _all_ configuration in conditional on the shield symbol
- [ ] `.conf` file has optional extra features commented out
- [ ] Keyboard/PCB is part of a shipped group buy or is generally available in stock to purchase (OSH/personal projects without general availability should create a zmk-config repo instead)
